### PR TITLE
feat: Axios 인스턴스 및 인터셉터 개선 (#26)

### DIFF
--- a/src/api/apiclient.ts
+++ b/src/api/apiclient.ts
@@ -1,14 +1,46 @@
-import axios from 'axios';
+// src/api/apiClient.ts
+import axios, { type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
-export const apiClient = axios.create({
-  baseURL: '/api/v1', // 실제 프로젝트 설정에 맞게 수정
+const BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+
+// 공통 axios 인스턴스
+export const axiosInstance: AxiosInstance = axios.create({
+  baseURL: BASE_URL,
   withCredentials: true,
 });
 
-apiClient.interceptors.response.use(
+// 공통 응답 처리
+axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
-    // TODO: 공통 에러 처리
+    const status = error.response?.status;
+
+    // 인증 만료 등
+    if (status === 401) {
+      console.warn('인증이 필요합니다.');
+    }
+
     return Promise.reject(error);
   }
 );
+
+// HTTP 메서드 래퍼
+export const apiClient = {
+  get: <T>(url: string, config?: Omit<AxiosRequestConfig, 'url'>) =>
+    axiosInstance.get<T>(url, config).then((res) => res.data),
+
+  post: <T>(
+    url: string,
+    data?: unknown,
+    config?: Omit<AxiosRequestConfig, 'url' | 'data'>
+  ) => axiosInstance.post<T>(url, data, config).then((res) => res.data),
+
+  put: <T>(
+    url: string,
+    data?: unknown,
+    config?: Omit<AxiosRequestConfig, 'url' | 'data'>
+  ) => axiosInstance.put<T>(url, data, config).then((res) => res.data),
+
+  delete: <T>(url: string, config?: Omit<AxiosRequestConfig, 'url'>) =>
+    axiosInstance.delete<T>(url, config).then((res) => res.data),
+} as const;

--- a/src/comment/services.ts
+++ b/src/comment/services.ts
@@ -1,35 +1,33 @@
 import { apiClient } from '@/api/apiclient';
 import type {
-  Comment,
   CommentListResponse,
   CreateCommentRequest,
   UpdateCommentRequest,
+  Comment,
 } from '@/types/api';
 
 export const commentService = {
+  // 댓글 목록 조회
   getComments(postId: number, page = 1, pageSize = 100) {
-    return apiClient
-      .get<CommentListResponse>(`/posts/${postId}/comments`, {
-        params: { page, page_size: pageSize },
-      })
-      .then((res) => res.data);
+    return apiClient.get<CommentListResponse>(`/posts/${postId}/comments`, {
+      params: { page, page_size: pageSize },
+    });
   },
 
   createComment(postId: number, data: CreateCommentRequest) {
-    return apiClient
-      .post<{ detail: string }>(`/posts/${postId}/comments`, data)
-      .then((res) => res.data);
+    return apiClient.post<Comment>(`/posts/${postId}/comments`, data);
   },
 
   updateComment(postId: number, commentId: number, data: UpdateCommentRequest) {
-    return apiClient
-      .patch<Comment>(`/posts/${postId}/comments/${commentId}`, data)
-      .then((res) => res.data);
+    return apiClient.put<Comment>(
+      `/posts/${postId}/comments/${commentId}`,
+      data
+    );
   },
 
   deleteComment(postId: number, commentId: number) {
-    return apiClient
-      .delete<{ detail: string }>(`/posts/${postId}/comments/${commentId}`)
-      .then((res) => res.data);
+    return apiClient.delete<{ detail: string }>(
+      `/posts/${postId}/comments/${commentId}`
+    );
   },
 };

--- a/src/store/comment/useCommentStore.ts
+++ b/src/store/comment/useCommentStore.ts
@@ -1,0 +1,72 @@
+// src/stores/comment/useCommentStore.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { commentService } from '@/comment/services';
+import type {
+  CommentListResponse,
+  CreateCommentRequest,
+  UpdateCommentRequest,
+} from '@/types/api';
+
+const QUERY_KEYS = {
+  comments: (postId: number) => ['comments', postId] as const,
+};
+
+export const useCommentStore = (postId: number) => {
+  const queryClient = useQueryClient();
+
+  // 댓글 목록 조회
+  const {
+    data: commentsData,
+    isLoading,
+    error,
+  } = useQuery<CommentListResponse>({
+    queryKey: QUERY_KEYS.comments(postId),
+    queryFn: () => commentService.getComments(postId),
+    enabled: !!postId,
+  });
+
+  // 댓글 생성
+  const createCommentMutation = useMutation({
+    mutationFn: (data: CreateCommentRequest) =>
+      commentService.createComment(postId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.comments(postId) });
+    },
+  });
+
+  // 댓글 수정
+  const updateCommentMutation = useMutation({
+    mutationFn: (params: { commentId: number; data: UpdateCommentRequest }) =>
+      commentService.updateComment(postId, params.commentId, params.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.comments(postId) });
+    },
+  });
+
+  // 댓글 삭제
+  const deleteCommentMutation = useMutation({
+    mutationFn: (commentId: number) =>
+      commentService.deleteComment(postId, commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.comments(postId) });
+    },
+  });
+
+  return {
+    // 데이터
+    comments: commentsData?.results || [],
+    count: commentsData?.count || 0,
+    isLoading,
+    error,
+
+    // 액션
+    createComment: createCommentMutation.mutate,
+    updateComment: updateCommentMutation.mutate,
+    deleteComment: deleteCommentMutation.mutate,
+
+    // 상태
+    isCreating: createCommentMutation.isPending,
+    isUpdating: updateCommentMutation.isPending,
+    isDeleting: deleteCommentMutation.isPending,
+  };
+};


### PR DESCRIPTION
## 기능 요약 

- 공통 axios 인스턴스를 `src/api/apiClient.ts`로 분리하고,
  응답 인터셉터에서 401 기본 처리를 추가했습니다.
- 댓글 도메인 API 호출을 `src/comment/services.ts`의 `commentService`로 분리해,
  React Query 훅에서는 서비스 레이어만 사용하도록 하는 기반을 마련했습니다.

## 변경 내용

- `src/api/apiClient.ts`
  - `axiosInstance` 생성 (baseURL, withCredentials 설정)
  - 응답 인터셉터에서 401 상태 코드 공통 처리
  - `apiClient.get/post/put/delete` 래퍼 추가 (`response.data`만 반환)

- `src/comment/services.ts`
  - `commentService.getComments/createComment/updateComment/deleteComment` 구현
  - axios 직접 호출 제거, `apiClient`만 사용하도록 정리

## 고민한 부분

- apiClient에서 `config` 객체 전체를 받을지, `url, data, config` 시그니처로 갈지 비교했고
  호출부 가독성을 위해 `url, data, config` 방식으로 선택했습니다.
- 서비스 레이어에서 응답을 그대로 반환하고,
  에러/UX 처리는 후속 단계(Queries 레이어)에서 맡기도록 역할을 나눴습니다.

## 리뷰 요청 포인트

- `apiClient → commentService → React Query` 로 이어지는 레이어 분리가
  이 프로젝트 규모에서 유지보수/확장성 측면에 적절한지 보고 싶습니다.
- apiClient에서 `response.data`만 반환하는 현재 설계가 괜찮은지,
  아니면 응답 전체를 넘기고 도메인 서비스에서 가공하는 패턴을 선호하시는지도 의견 부탁드립니다.

## 관련 파일

- `src/api/apiClient.ts`
- `src/comment/services.ts`
