### PR TITLE
feat: #36 댓글 API 백엔드 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@tiptap/extension-font-family": "^3.14.0",
         "@tiptap/extension-highlight": "^3.14.0",
         "@tiptap/extension-image": "^3.14.0",
+        "@tiptap/extension-link": "^3.14.0",
         "@tiptap/extension-placeholder": "^3.14.0",
         "@tiptap/extension-text-align": "^3.14.0",
         "@tiptap/extension-text-style": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tiptap/extension-font-family": "^3.14.0",
     "@tiptap/extension-highlight": "^3.14.0",
     "@tiptap/extension-image": "^3.14.0",
+    "@tiptap/extension-link": "^3.14.0",
     "@tiptap/extension-placeholder": "^3.14.0",
     "@tiptap/extension-text-align": "^3.14.0",
     "@tiptap/extension-text-style": "^3.14.0",

--- a/src/api/comment/services.ts
+++ b/src/api/comment/services.ts
@@ -1,18 +1,20 @@
+// src/api/comment/services.ts
+
 import { apiClient } from '@/api/apiclient';
 import type {
-  CommentListResponse,
+  CommentListResponseDTO,
+  CommentDTO,
   CreateCommentRequest,
   UpdateCommentRequest,
-  Comment,
-} from '@/types/api';
+} from '@/api/comment/model/commentDTO';
 
 const BASE_PATH = '/api/v1/posts';
 
 export const commentService = {
   // 댓글 목록 조회
   getComments(postId: number, page = 1, pageSize = 100) {
-    return apiClient.get<CommentListResponse>(
-      `${BASE_PATH}/${postId}/comments`,
+    return apiClient.get<CommentListResponseDTO>(
+      `${BASE_PATH}/${postId}/comments/`,
       {
         params: { page, page_size: pageSize },
       }
@@ -21,13 +23,13 @@ export const commentService = {
 
   // 댓글 생성
   createComment(postId: number, data: CreateCommentRequest) {
-    return apiClient.post<Comment>(`${BASE_PATH}/${postId}/comments`, data);
+    return apiClient.post<CommentDTO>(`${BASE_PATH}/${postId}/comments/`, data);
   },
 
   // 댓글 수정
   updateComment(postId: number, commentId: number, data: UpdateCommentRequest) {
-    return apiClient.put<Comment>(
-      `${BASE_PATH}/${postId}/comments/${commentId}`,
+    return apiClient.put<CommentDTO>(
+      `${BASE_PATH}/${postId}/comments/${commentId}/`,
       data
     );
   },
@@ -35,7 +37,7 @@ export const commentService = {
   // 댓글 삭제
   deleteComment(postId: number, commentId: number) {
     return apiClient.delete<{ detail: string }>(
-      `${BASE_PATH}/${postId}/comments/${commentId}`
+      `${BASE_PATH}/${postId}/comments/${commentId}/`
     );
   },
 };

--- a/src/api/comment/services.ts
+++ b/src/api/comment/services.ts
@@ -6,28 +6,36 @@ import type {
   Comment,
 } from '@/types/api';
 
+const BASE_PATH = '/api/v1/posts';
+
 export const commentService = {
   // 댓글 목록 조회
   getComments(postId: number, page = 1, pageSize = 100) {
-    return apiClient.get<CommentListResponse>(`/posts/${postId}/comments`, {
-      params: { page, page_size: pageSize },
-    });
+    return apiClient.get<CommentListResponse>(
+      `${BASE_PATH}/${postId}/comments`,
+      {
+        params: { page, page_size: pageSize },
+      }
+    );
   },
 
+  // 댓글 생성
   createComment(postId: number, data: CreateCommentRequest) {
-    return apiClient.post<Comment>(`/posts/${postId}/comments`, data);
+    return apiClient.post<Comment>(`${BASE_PATH}/${postId}/comments`, data);
   },
 
+  // 댓글 수정
   updateComment(postId: number, commentId: number, data: UpdateCommentRequest) {
     return apiClient.put<Comment>(
-      `/posts/${postId}/comments/${commentId}`,
+      `${BASE_PATH}/${postId}/comments/${commentId}`,
       data
     );
   },
 
+  // 댓글 삭제
   deleteComment(postId: number, commentId: number) {
     return apiClient.delete<{ detail: string }>(
-      `/posts/${postId}/comments/${commentId}`
+      `${BASE_PATH}/${postId}/comments/${commentId}`
     );
   },
 };

--- a/src/api/model/commentDTO.ts
+++ b/src/api/model/commentDTO.ts
@@ -1,0 +1,27 @@
+// src/api/comment/model/commentDTO.ts
+
+import type { UserDTO } from '@/api/model/postDTO';
+
+export interface CommentListResponseDTO {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: CommentDTO[];
+}
+
+export interface CommentDTO {
+  id: number;
+  author: UserDTO;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// 요청 DTO
+export interface CreateCommentRequest {
+  content: string;
+}
+
+export interface UpdateCommentRequest {
+  content: string;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,24 +2,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-// import './index.css'  // 일단 주석 처리하고 테스트
 
-async function enableMocking() {
-  if (process.env.NODE_ENV !== 'development') {
-    return;
-  }
-
-  const { worker } = await import('./mocks/browser');
-
-  return worker.start({
-    onUnhandledRequest: 'bypass', // 다른 API 요청은 그대로 통과
-  });
-}
-
-enableMocking().then(() => {
-  ReactDOM.createRoot(document.getElementById('root')!).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  );
-});
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -2,13 +2,20 @@
 import { http, HttpResponse } from 'msw';
 
 export const handlers = [
-  // ...다른 핸들러들
-
+  // ✅ 여기에는 기존에 쓰던 다른 목 핸들러들이 올 수 있음.
+  // 예: 로그인, 회원가입, 다른 도메인 API 등
+  // 예시)
+  // http.get('/api/v1/example', () => {
+  //   return HttpResponse.json({ message: 'ok' }, { status: 200 });
+  // }),
+  // ============================
+  // 댓글 관련 핸들러 (현재 비활성화)
+  // ============================
+  /*
   // 댓글 수정
   http.put(
     '/api/v1/posts/:postId/comments/:commentId',
     async ({ request, params }) => {
-      // request.json() 결과에 타입 지정
       const body = (await request.json()) as { content: string };
       const { commentId } = params;
 
@@ -18,16 +25,17 @@ export const handlers = [
           content: body.content,
           updated_at: new Date().toISOString(),
         },
-        { status: 200 }
+        { status: 200 },
       );
-    }
+    },
   ),
 
   // 댓글 삭제
   http.delete('/api/v1/posts/:postId/comments/:commentId', () => {
     return HttpResponse.json(
       { detail: '댓글이 삭제되었습니다.' },
-      { status: 200 }
+      { status: 200 },
     );
   }),
+  */
 ];

--- a/src/pages/communitydetail/communitydetailpage.tsx
+++ b/src/pages/communitydetail/communitydetailpage.tsx
@@ -137,10 +137,9 @@ function CommunityDetailPage() {
       views: 60,
       likes: 2,
       createdAt: '15시간 전',
-      comments:
-        convertedComments.length > 0 ? convertedComments : dummyComments,
+      comments: convertedComments,
     }),
-    [id, convertedComments, dummyComments]
+    [id, convertedComments]
   );
 
   // 초기 댓글 페이지 설정

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import path from 'path'
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
+import path from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -11,4 +11,13 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-})
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://community.ozcodingschool.site/',
+        changeOrigin: true,
+        secure: true,
+      },
+    },
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,9 @@
+// vite.config.ts
 import path from 'path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -14,7 +14,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'https://community.ozcodingschool.site/',
+        target: 'https://api.ozcodingschool.site',
         changeOrigin: true,
         secure: true,
       },


### PR DESCRIPTION
## 작업 내용
- 백엔드 스웨거 스펙 기준 댓글 DTO 정의
  - `CommentListResponseDTO`, `CommentDTO`
  - `CreateCommentRequest`, `UpdateCommentRequest`
- `commentService`를 `/api/v1/posts/:postId/comments/` 스펙에 맞게 수정
  - 목록/생성/수정/삭제 엔드포인트 및 타입 연동
- 개발 환경에서 msw 영향 제거
  - `main.tsx`에서 mock worker 비활성화
  - 댓글 관련 msw 핸들러 주석 처리

## 체크 사항 1
- [ ] 로컬에서 Service Worker unregister 후, 실제 백엔드 댓글 생성/조회 응답 확인
- [ ] 댓글 목록/작성 UI에서 필드 매핑(`author`, `created_at` 등) 정상 동작 확인


## 체크 사항 2
- 스웨거 스펙 기준으로 댓글 CRUD API 연동을 완료했으나,
  현재 로컬 크롬에는 브라우저에 등록된 Service Worker(msw)가 아직 살아 있어서 
  댓글 API 요청이 진짜 백엔드가 아니라 목 서버에서 404로 처리되고 있습니다.
