### PR TITLE
Feat/#39/commu api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-navigation-menu": "^1.2.14",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -1992,6 +1993,99 @@
       }
     },
     "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-navigation-menu": "^1.2.14",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/src/api/apiclient.ts
+++ b/src/api/apiclient.ts
@@ -1,4 +1,5 @@
 // src/api/apiClient.ts
+import { useAuthStore } from '@/store/authStore';
 import axios, { type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
@@ -8,6 +9,20 @@ export const axiosInstance: AxiosInstance = axios.create({
   baseURL: BASE_URL,
   withCredentials: true,
 });
+
+// 공통 요청 처리
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const { access_token } = useAuthStore.getState();
+
+    if (access_token) {
+      config.headers.Authorization = `Bearer ${access_token}`;
+    }
+
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
 
 // 공통 응답 처리
 axiosInstance.interceptors.response.use(

--- a/src/api/auth/dto.ts
+++ b/src/api/auth/dto.ts
@@ -1,0 +1,22 @@
+export interface LoginRequestDTO {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponseDTO {
+  access_token: string;
+}
+
+export interface UserResponseDTO {
+  id: number;
+  email: string;
+  name: string;
+  nickname: string;
+  phone_number: string;
+  gender: string;
+  birthday: string;
+  role: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/api/auth/queries.ts
+++ b/src/api/auth/queries.ts
@@ -1,0 +1,9 @@
+import { authService } from './services';
+
+export const authQueries = {};
+
+export const authMutations = {
+  login: {
+    mutationFn: authService.login,
+  },
+};

--- a/src/api/auth/queries.ts
+++ b/src/api/auth/queries.ts
@@ -1,6 +1,14 @@
+import { queryOptions } from '@tanstack/react-query';
 import { authService } from './services';
 
-export const authQueries = {};
+export const authQueries = {
+  getUser: () =>
+    queryOptions({
+      queryKey: ['auth-user'],
+      queryFn: authService.getUserInfo,
+      enabled: false,
+    }),
+};
 
 export const authMutations = {
   login: {

--- a/src/api/auth/services.ts
+++ b/src/api/auth/services.ts
@@ -1,4 +1,3 @@
-import { useAuthStore } from '@/store/authStore';
 import { apiClient } from '../apiclient';
 import type { LoginRequestDTO, LoginResponseDTO, UserResponseDTO } from './dto';
 
@@ -13,8 +12,6 @@ export const authService = {
       password,
     });
 
-    useAuthStore.getState().login(response.access_token);
-    console.log('로그인 성공:', response);
     return response;
   },
   // 유저정보 가져오기 서비스

--- a/src/api/auth/services.ts
+++ b/src/api/auth/services.ts
@@ -8,13 +8,13 @@ export const authService = {
     email,
     password,
   }: LoginRequestDTO): Promise<LoginResponseDTO> => {
-    const response = await apiClient.post<LoginResponseDTO>('/auth/login', {
+    const response = await apiClient.post<LoginResponseDTO>('/accounts/login', {
       email,
       password,
     });
 
     useAuthStore.getState().login(response.access_token);
-
+    console.log('로그인 성공:', response);
     return response;
   },
   // 유저정보 가져오기 서비스

--- a/src/api/auth/services.ts
+++ b/src/api/auth/services.ts
@@ -1,0 +1,28 @@
+import { useAuthStore } from '@/store/authStore';
+import { apiClient } from '../apiclient';
+import type { LoginRequestDTO, LoginResponseDTO, UserResponseDTO } from './dto';
+
+export const authService = {
+  // 로그인 서비스
+  login: async ({
+    email,
+    password,
+  }: LoginRequestDTO): Promise<LoginResponseDTO> => {
+    const response = await apiClient.post<LoginResponseDTO>('/auth/login', {
+      email,
+      password,
+    });
+
+    useAuthStore.getState().login(response.access_token);
+
+    return response;
+  },
+  // 유저정보 가져오기 서비스
+  getUserInfo: async (): Promise<UserResponseDTO> => {
+    const response = await apiClient.get<UserResponseDTO>('/accounts/me');
+
+    return response;
+  },
+
+  // 로그아웃 서비스
+};

--- a/src/components/CommunityPage/NavigationBar.tsx
+++ b/src/components/CommunityPage/NavigationBar.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router';
 import { useAuthStore } from '@/store';
 import { ROUTES } from '@/routes';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import UserProfile from '../auth/UserProfile';
 
 export const NavigationBar = () => {
   const { user } = useAuthStore();
@@ -8,8 +10,8 @@ export const NavigationBar = () => {
 
   return (
     <nav className="sticky top-0 z-50">
-      <section className="bg-oz-gray-black-dark flex h-[48px] w-full items-center justify-center">
-        <p className="text-[16px] font-light text-white">
+      <section className="bg-oz-gray-black-dark flex w-full items-center justify-center py-1">
+        <p className="text-md font-light text-white">
           🚨 선착순 모집! 국비지원 받고 4주 완성
         </p>
       </section>
@@ -35,14 +37,10 @@ export const NavigationBar = () => {
           <div className="flex items-center justify-end gap-2">
             <div className="text-oz-gray-dark flex items-center justify-center gap-2">
               {isAuthenticated ? (
-                <Link to="/profile">
-                  <img
-                    src={user?.profile_img_url ?? '/src/assets/user.png'}
-                    alt="user-icon"
-                    className="size-[40px] rounded-full"
-                  />
-                </Link>
+                // <Link to="/profile">
+                <UserProfile />
               ) : (
+                // </Link>
                 <span className="text-oz-gray-dark flex items-center justify-center gap-2 text-[16px]">
                   <Link
                     to={ROUTES.LOGIN}

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -1,0 +1,36 @@
+import { useAuthStore } from '@/store/authStore';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { Button } from '../ui/button';
+import { useMutation } from '@tanstack/react-query';
+import { authMutations } from '@/api/auth/queries';
+
+const UserProfile = () => {
+  const { user } = useAuthStore();
+  const { mutate } = useMutation(authMutations.login);
+
+  const handleLogin = () => {
+    mutate({
+      email: 'testuser8@ozcodingschool.site',
+      password: 'Ozcoding1234@',
+    });
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <img
+          src={'/src/assets/user.png'}
+          alt="user-icon"
+          className="size-[40px] rounded-full"
+        />
+      </PopoverTrigger>
+      <PopoverContent>
+        <Button variant="link" onClick={handleLogin}>
+          로그인
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default UserProfile;

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -1,15 +1,12 @@
-import { useAuthStore } from '@/store/authStore';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Button } from '../ui/button';
-import { useMutation } from '@tanstack/react-query';
-import { authMutations } from '@/api/auth/queries';
+import { useLogin } from '@/hooks/useLogIn';
 
 const UserProfile = () => {
-  const { user } = useAuthStore();
-  const { mutate } = useMutation(authMutations.login);
+  const { login } = useLogin();
 
   const handleLogin = () => {
-    mutate({
+    login({
       email: 'testuser8@ozcodingschool.site',
       password: 'Ozcoding1234@',
     });

--- a/src/components/editor/api/dto.ts
+++ b/src/components/editor/api/dto.ts
@@ -30,3 +30,16 @@ export interface authorDTO {
   nickname: string;
   profile_image_url: string;
 }
+
+export interface CreateCommunityRequestDTO {
+  title: string;
+  content: string;
+  category: number;
+}
+
+export interface CreateCommunityResponseDTO {
+  id: number;
+  title: string;
+  content: string;
+  category: number;
+}

--- a/src/components/editor/api/queries.ts
+++ b/src/components/editor/api/queries.ts
@@ -20,3 +20,9 @@ export const communityQueries = {
       enabled: Boolean(params.id) && params.enabled !== false,
     }),
 };
+
+export const communityMutations = {
+  postCommunityCreate: {
+    mutationFn: communityService.postCommunityPost,
+  },
+};

--- a/src/components/editor/api/queries.ts
+++ b/src/components/editor/api/queries.ts
@@ -1,5 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 import { communityService } from './services';
+import type { CreateCommunityRequestDTO } from './dto';
 
 export const communityQueries = {
   getCategories: () =>
@@ -24,5 +25,14 @@ export const communityQueries = {
 export const communityMutations = {
   postCommunityCreate: {
     mutationFn: communityService.postCommunityPost,
+  },
+  updateCommunityPost: {
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: CreateCommunityRequestDTO;
+    }) => communityService.patchCommunityPost(id, data),
   },
 };

--- a/src/components/editor/api/services.ts
+++ b/src/components/editor/api/services.ts
@@ -29,4 +29,14 @@ export const communityService = {
     );
     return response;
   },
+  patchCommunityPost: async (
+    id: number,
+    data: CreateCommunityRequestDTO
+  ): Promise<CreateCommunityResponseDTO> => {
+    const response = await apiClient.put<CreateCommunityResponseDTO>(
+      `/posts/${id}`,
+      data
+    );
+    return response;
+  },
 };

--- a/src/components/editor/api/services.ts
+++ b/src/components/editor/api/services.ts
@@ -1,15 +1,32 @@
 import { apiClient } from '@/api/apiclient';
-import type { CategoryResponseDTO, CommunityDetailResponseDTO } from './dto';
+import type {
+  CategoryResponseDTO,
+  CommunityDetailResponseDTO,
+  CreateCommunityRequestDTO,
+  CreateCommunityResponseDTO,
+} from './dto';
 
 export const communityService = {
   getCategories: async (): Promise<CategoryResponseDTO> => {
-    const response = await apiClient.get<CategoryResponseDTO>('categories');
+    const response =
+      await apiClient.get<CategoryResponseDTO>('/posts/categories');
     return response;
   },
   getPostDetailById: async (
     id: number
   ): Promise<CommunityDetailResponseDTO> => {
-    const response = await apiClient.get<CommunityDetailResponseDTO>(`/${id}`);
+    const response = await apiClient.get<CommunityDetailResponseDTO>(
+      `/posts/${id}`
+    );
+    return response;
+  },
+  postCommunityPost: async (
+    data: CreateCommunityRequestDTO
+  ): Promise<CreateCommunityResponseDTO> => {
+    const response = await apiClient.post<CreateCommunityResponseDTO>(
+      '/posts',
+      data
+    );
     return response;
   },
 };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,31 @@
+import type { LoginRequestDTO } from '@/api/auth/dto';
+import { authMutations, authQueries } from '@/api/auth/queries';
+import { useAuthStore } from '@/store/authStore';
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+export const useLogin = () => {
+  const { setToken, setUser } = useAuthStore();
+
+  const loginMutation = useMutation(authMutations.login);
+  const userQuery = useQuery(authQueries.getUser());
+
+  const login = (data: LoginRequestDTO) => {
+    loginMutation.mutate(data, {
+      onSuccess: async (res) => {
+        setToken(res.access_token);
+
+        const result = await userQuery.refetch();
+
+        if (result.data) {
+          setUser(result.data);
+        }
+      },
+    });
+  };
+
+  return {
+    login,
+    isLoading: loginMutation.isPending,
+    isError: loginMutation.isError,
+  };
+};

--- a/src/pages/communitycreate/communitycreatepage.tsx
+++ b/src/pages/communitycreate/communitycreatepage.tsx
@@ -16,9 +16,10 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useTextEditor } from '@/hooks/tiptap';
+import { ROUTES } from '@/routes';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 
 type Mode = 'create' | 'edit';
 
@@ -26,6 +27,7 @@ function CommunityCreatePage({ mode }: { mode: Mode }) {
   // 수정일 때만 게시글 조회
   const { id } = useParams<{ id: string }>();
   const isEdit = mode === 'edit';
+  const navigate = useNavigate();
 
   const [title, setTitle] = useState('');
   const [categoryId, setCategoryId] = useState<number | null>(null);
@@ -47,17 +49,48 @@ function CommunityCreatePage({ mode }: { mode: Mode }) {
   );
 
   // 게시글 생성
-  const { mutate: createPost, isPending } = useMutation(
+  const { mutate: createPost } = useMutation(
     communityMutations.postCommunityCreate
   );
-  const handleSubmit = () => {
-    createPost({
-      title,
-      content,
-      category: categoryId!,
-    });
-  };
 
+  const { mutate: updatePost } = useMutation(
+    communityMutations.updateCommunityPost
+  );
+  const handleSubmit = () => {
+    if (!categoryId) return;
+    if (isEdit && id) {
+      updatePost(
+        {
+          id: Number(id),
+          data: {
+            title,
+            content,
+            category: categoryId!,
+          },
+        },
+        {
+          onSuccess: () => {
+            // 성공 시 처리 로직
+            navigate(ROUTES.COMMUNITY);
+          },
+        }
+      );
+    } else {
+      createPost(
+        {
+          title,
+          content,
+          category: categoryId!,
+        },
+        {
+          onSuccess: () => {
+            // 성공 시 처리 로직
+            navigate(ROUTES.COMMUNITY);
+          },
+        }
+      );
+    }
+  };
   useEffect(() => {
     if (!postDetail || !editor) return;
 
@@ -111,5 +144,4 @@ function CommunityCreatePage({ mode }: { mode: Mode }) {
     </div>
   );
 }
-
 export default CommunityCreatePage;

--- a/src/pages/communitycreate/communitycreatepage.tsx
+++ b/src/pages/communitycreate/communitycreatepage.tsx
@@ -1,4 +1,7 @@
-import { communityQueries } from '@/components/editor/api/queries';
+import {
+  communityMutations,
+  communityQueries,
+} from '@/components/editor/api/queries';
 import EditorHeader from '@/components/editor/ui/EditorHeader';
 import TipTap from '@/components/editor/ui/TipTap';
 import ToolBar from '@/components/editor/ui/ToolBarBtn';
@@ -13,7 +16,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useTextEditor } from '@/hooks/tiptap';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 
@@ -27,7 +30,7 @@ function CommunityCreatePage({ mode }: { mode: Mode }) {
   const [title, setTitle] = useState('');
   const [categoryId, setCategoryId] = useState<number | null>(null);
   const [content, setContent] = useState('');
-  console.log(content);
+
   // 카테고리 목록 조회
   const { data: categories } = useQuery(communityQueries.getCategories());
   const categoriesList = categories?.results ?? [];
@@ -42,6 +45,18 @@ function CommunityCreatePage({ mode }: { mode: Mode }) {
   const { data: postDetail } = useQuery(
     communityQueries.getCommunityDetail({ id: Number(id), enabled: isEdit })
   );
+
+  // 게시글 생성
+  const { mutate: createPost, isPending } = useMutation(
+    communityMutations.postCommunityCreate
+  );
+  const handleSubmit = () => {
+    createPost({
+      title,
+      content,
+      category: categoryId!,
+    });
+  };
 
   useEffect(() => {
     if (!postDetail || !editor) return;
@@ -89,7 +104,9 @@ function CommunityCreatePage({ mode }: { mode: Mode }) {
           <ToolBar editor={editor} />
           <TipTap editor={editor} />
         </div>
-        <Button className="ml-auto">{isEdit ? '수정하기' : '등록하기'}</Button>
+        <Button onClick={handleSubmit} className="ml-auto">
+          {isEdit ? '수정하기' : '등록하기'}
+        </Button>
       </div>
     </div>
   );

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -6,7 +6,7 @@ interface AuthStore {
   user: UserResponseDTO | null;
   access_token: string | null;
   isAuthenticated: boolean;
-  login: (accessToken: string) => void;
+  setToken: (accessToken: string) => void;
   logout: () => void;
   setUser: (user: UserResponseDTO | null) => void;
 }
@@ -17,7 +17,7 @@ export const useAuthStore = create<AuthStore>()(
       user: null,
       isAuthenticated: false,
       access_token: null,
-      login: (access_token) => set({ isAuthenticated: true, access_token }),
+      setToken: (access_token) => set({ isAuthenticated: true, access_token }),
       logout: () =>
         set({ user: null, isAuthenticated: false, access_token: null }),
       setUser: (user) => set({ user }),

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,29 @@
+import type { UserResponseDTO } from '@/api/auth/dto';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface AuthStore {
+  user: UserResponseDTO | null;
+  access_token: string | null;
+  isAuthenticated: boolean;
+  login: (accessToken: string) => void;
+  logout: () => void;
+  setUser: (user: UserResponseDTO | null) => void;
+}
+
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    (set) => ({
+      user: null,
+      isAuthenticated: false,
+      access_token: null,
+      login: (access_token) => set({ isAuthenticated: true, access_token }),
+      logout: () =>
+        set({ user: null, isAuthenticated: false, access_token: null }),
+      setUser: (user) => set({ user }),
+    }),
+    {
+      name: 'auth_store',
+    }
+  )
+);


### PR DESCRIPTION
## 📝 작업 개요

- 로그인 플로우 구현 및 인증 헤더 설정
- 커뮤니티 게시글 작성 / 수정 페이지 통합 및 API 연동

## 📌 작업 상세 내용

- [ ]  테스트 계정 기반 로그인 기능 구현
  - 로그인 시 access token 저장 (zustand)
  - axios interceptor를 통한 인증 헤더 자동 설정
  
- [ ] 토큰 기반 유저 정보 조회 API 연동
  - 로그인 이후 /accounts/me 호출로 유저 정보 상태 관리

- [ ] 커뮤니티 게시글 작성 API 연동
  - 카테고리 / 제목 / 내용 입력 후 게시글 생성

- [ ] 커뮤니티 게시글 수정 API 연동
  - 기존 게시글 데이터 조회 후 초기값 세팅

 - [ ] 작성 / 수정 페이지 공통 컴포넌트 구조로 통합 (mode 기반 분기)
 
## 🔍 체크 리스트

- [ ] 디자인/플로우 문서와 구현 내용이 일치합니다.
- [ ] `npm run lint` 실행 시 에러/경고가 없습니다.
- [ ] `npm test` 실행 시 실패하는 테스트가 없습니다.
- [ ] 비회원 / 회원 / 작성자 플로우를 브라우저에서 직접 확인했습니다.

## ✅ 테스트 결과

- [ ] 데스크톱 크롬에서 주요 기능 동작 확인
- [ ] (선택) 모바일 뷰에서 주요 기능 동작 확인

## 👀 리뷰어에게 공유 사항

- 리뷰 시 특히 집중해서 봐줬으면 하는 부분
- 고민되거나 논의가 필요했던 포인트
